### PR TITLE
fix: configure path alias for components and libs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["dom", "dom.iterable", "es2020"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2020"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -12,9 +16,29 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "types": ["node"],
-    "incremental": true
+    "types": [
+      "node"
+    ],
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/types/pdf-parse.d.ts
+++ b/types/pdf-parse.d.ts
@@ -1,0 +1,8 @@
+declare module 'pdf-parse' {
+  interface PdfData {
+    text: string
+    [key: string]: unknown
+  }
+  function pdfParse(buffer: Buffer | Uint8Array, options?: unknown): Promise<PdfData>
+  export default pdfParse
+}


### PR DESCRIPTION
## Summary
- map `@/*` alias to project root in tsconfig for Next.js module resolution
- add TypeScript declarations for `pdf-parse`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint .` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a88259b1c832683830fe165ff14bf