### PR TITLE
Add career support tips and loading progress bar

### DIFF
--- a/app/api/complete/route.ts
+++ b/app/api/complete/route.ts
@@ -22,7 +22,8 @@ export async function POST(req: Request) {
     "projects": [{"title": string, "industry": string, "scale": string, "role": string, "period": string, "summary": string}],
     "domains": string[],
     "certifications": string[],
-    "management": {"teamSize": string, "period": string, "description": string}
+    "management": {"teamSize": string, "period": string, "description": string},
+    "careerSupport": string[]
   }
 }`;
 
@@ -37,6 +38,7 @@ ${JSON.stringify(history || [], null, 2)}
 - 「recommendedAssignments」には、SHIFT内でのアサイン先の例（領域/業界/ポジション）を3〜6件挙げる。
 - 「skills」は5〜10個にまとめ、レベルは1〜5。
 - 名前が不明な場合は空に。
+- 「careerSupport」には、スキルアップのための具体的な手段を3〜5件挙げる。
 - 日本語で、ビジネス文書のトーン。`;
 
   const res = await openai.chat.completions.create({

--- a/app/cv/page.tsx
+++ b/app/cv/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import SkillRadar from "@/components/SkillRadar";
 import StarRating from "@/components/StarRating";
+import ProgressBar from "@/components/ProgressBar";
 
 type CV = {
   name: string;
@@ -15,12 +16,14 @@ type CV = {
   domains: string[];
   certifications: string[];
   management?: { teamSize?: string; period?: string; description?: string; };
+  careerSupport?: string[];
 };
 
 export default function CVPage() {
   const [cv, setCv] = useState<CV | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [progress, setProgress] = useState(0);
 
   useEffect(() => {
     const run = async () => {
@@ -48,7 +51,25 @@ export default function CVPage() {
     run();
   }, []);
 
-  if (loading) return <div className="text-center text-slate-600">CVを生成しています...</div>;
+  useEffect(() => {
+    if (!loading) {
+      setProgress(100);
+      return;
+    }
+    setProgress(0);
+    const timer = setInterval(() => {
+      setProgress((p) => (p < 90 ? p + Math.random() * 10 : p));
+    }, 500);
+    return () => clearInterval(timer);
+  }, [loading]);
+
+  if (loading)
+    return (
+      <div className="grid gap-4 place-items-center">
+        <div className="text-center text-slate-600">CVを生成しています...</div>
+        <ProgressBar value={progress} />
+      </div>
+    );
   if (error) return <div className="text-center text-red-600">{error}</div>;
   if (!cv) return <div className="text-center">データがありません</div>;
 
@@ -124,6 +145,17 @@ export default function CVPage() {
           ))}
         </div>
       </section>
+
+      {cv.careerSupport && (
+        <section className="card p-6">
+          <h2 className="text-lg font-semibold mb-3">キャリアサポート</h2>
+          <ul className="list-disc list-inside text-sm text-slate-700 space-y-1">
+            {cv.careerSupport.map((tip) => (
+              <li key={tip}>{tip}</li>
+            ))}
+          </ul>
+        </section>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Show a dynamic progress bar while the CV is being generated
- Provide detailed career support tips once the CV is ready

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689a8f843be88326a3171a2aafb8bb04