### PR TITLE
Add career support tips and loading progress bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+.DS_Store

--- a/app/api/complete/route.ts
+++ b/app/api/complete/route.ts
@@ -22,7 +22,20 @@ export async function POST(req: Request) {
     "projects": [{"title": string, "industry": string, "scale": string, "role": string, "period": string, "summary": string}],
     "domains": string[],
     "certifications": string[],
-    "management": {"teamSize": string, "period": string, "description": string}
+    "management": {"teamSize": string, "period": string, "description": string},
+    "careerSupport": {
+      "targetRoles": string[],
+      "salaryProgression": [{"stage": string, "amount": string}],
+      "skillGap": {"current": string, "goal": string, "reason": string},
+      "roadmap": {
+        "0-3m": [{"action": string, "metric": string}],
+        "3-6m": [{"action": string, "metric": string}],
+        "6-12m": [{"action": string, "metric": string}]
+      },
+      "recommendedCertifications": [{"name": string, "reason": string, "timing": string}],
+      "learningPlan": [{"topic": string, "modules": string[], "tasks": string[]}],
+      "mentoringTips": string[]
+    }
   }
 }`;
 
@@ -37,6 +50,7 @@ ${JSON.stringify(history || [], null, 2)}
 - 「recommendedAssignments」には、SHIFT内でのアサイン先の例（領域/業界/ポジション）を3〜6件挙げる。
 - 「skills」は5〜10個にまとめ、レベルは1〜5。
 - 名前が不明な場合は空に。
+- 「careerSupport」には、目指せるロール、想定年収の推移、現状→目標のスキルギャップ（理由付き）、0–3ヶ月/3–6ヶ月/6–12ヶ月のロードマップ（各フェーズの具体アクションとメトリクス）、推奨資格（理由・実施タイミング）、学習計画（トピックとモジュール、実践課題）、メンタリング活用Tipsを含める。
 - 日本語で、ビジネス文書のトーン。`;
 
   const res = await openai.chat.completions.create({


### PR DESCRIPTION
## Summary
- Structure `careerSupport` in CV API to include roles, salary outlook, skill gaps, roadmaps, certifications, learning plans, and mentoring tips
- Render comprehensive career support section with unified card styling on CV page
- Ignore Node-related artifacts with `.gitignore`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689a8f843be88326a3171a2aafb8bb04