### PR TITLE
feat: enhance career support section

### DIFF
--- a/app/api/complete/route.ts
+++ b/app/api/complete/route.ts
@@ -23,7 +23,19 @@ export async function POST(req: Request) {
     "domains": string[],
     "certifications": string[],
     "management": {"teamSize": string, "period": string, "description": string},
-    "careerSupport": string[]
+    "careerSupport": {
+      "targetRoles": string[],
+      "salaryTrend": [{"stage": string, "value": number}],
+      "skillGap": {"current": string, "target": string, "reason": string},
+      "roadmap": {
+        "0-3m": {"actions": string[], "metrics": string[]},
+        "3-6m": {"actions": string[], "metrics": string[]},
+        "6-12m": {"actions": string[], "metrics": string[]}
+      },
+      "certifications": [{"name": string, "reason": string, "timing": string}],
+      "learningPlan": [{"topic": string, "module": string, "task": string}],
+      "mentoringTips": string[]
+    }
   }
 }`;
 
@@ -38,7 +50,14 @@ ${JSON.stringify(history || [], null, 2)}
 - 「recommendedAssignments」には、SHIFT内でのアサイン先の例（領域/業界/ポジション）を3〜6件挙げる。
 - 「skills」は5〜10個にまとめ、レベルは1〜5。
 - 名前が不明な場合は空に。
-- 「careerSupport」には、スキルアップのための具体的な手段を3〜5件挙げる。
+- 「careerSupport」では以下を詳述する:
+  - 「targetRoles」: 将来的に目指せるロールを2〜4件。
+  - 「salaryTrend": 年収の推移を段階ごとに数値で3〜5点。
+  - 「skillGap": 現状と目標のギャップ、その理由。
+  - 「roadmap": 0–3ヶ月、3–6ヶ月、6–12ヶ月の各期間でのアクションとメトリクス。
+  - 「certifications": 推奨資格と理由、実施タイミング。
+  - 「learningPlan": 学習トピック、モジュール、実践課題。
+  - 「mentoringTips": メンタリング活用の具体的な提案を3件程度。
 - 日本語で、ビジネス文書のトーン。`;
 
   const res = await openai.chat.completions.create({

--- a/app/cv/page.tsx
+++ b/app/cv/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import SkillRadar from "@/components/SkillRadar";
 import StarRating from "@/components/StarRating";
 import ProgressBar from "@/components/ProgressBar";
+import SalaryChart from "@/components/SalaryChart";
 
 type CV = {
   name: string;
@@ -16,7 +17,19 @@ type CV = {
   domains: string[];
   certifications: string[];
   management?: { teamSize?: string; period?: string; description?: string; };
-  careerSupport?: string[];
+  careerSupport?: {
+    targetRoles: string[];
+    salaryTrend: { stage: string; value: number }[];
+    skillGap: { current: string; target: string; reason: string };
+    roadmap: {
+      "0-3m": { actions: string[]; metrics: string[] };
+      "3-6m": { actions: string[]; metrics: string[] };
+      "6-12m": { actions: string[]; metrics: string[] };
+    };
+    certifications: { name: string; reason: string; timing: string }[];
+    learningPlan: { topic: string; module: string; task: string }[];
+    mentoringTips: string[];
+  };
 };
 
 export default function CVPage() {
@@ -148,12 +161,88 @@ export default function CVPage() {
 
       {cv.careerSupport && (
         <section className="card p-6">
-          <h2 className="text-lg font-semibold mb-3">キャリアサポート</h2>
-          <ul className="list-disc list-inside text-sm text-slate-700 space-y-1">
-            {cv.careerSupport.map((tip) => (
-              <li key={tip}>{tip}</li>
-            ))}
-          </ul>
+          <h2 className="text-lg font-semibold mb-6">キャリアサポート</h2>
+          <div className="grid gap-6">
+            <div>
+              <h3 className="text-base font-semibold">目指せるロール</h3>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {cv.careerSupport.targetRoles.map((r) => (
+                  <span key={r} className="badge">
+                    {r}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <h3 className="text-base font-semibold">年収の推移</h3>
+              <div className="mt-2">
+                <SalaryChart data={cv.careerSupport.salaryTrend} />
+              </div>
+            </div>
+
+            <div>
+              <h3 className="text-base font-semibold">スキルギャップ</h3>
+              <p className="text-sm text-slate-700 mt-1">現状: {cv.careerSupport.skillGap.current}</p>
+              <p className="text-sm text-slate-700">目標: {cv.careerSupport.skillGap.target}</p>
+              <p className="text-xs text-slate-500 mt-1">理由: {cv.careerSupport.skillGap.reason}</p>
+            </div>
+
+            <div>
+              <h3 className="text-base font-semibold">ロードマップ</h3>
+              <div className="mt-2 grid md:grid-cols-3 gap-4 text-sm">
+                {Object.entries(cv.careerSupport.roadmap).map(([period, plan]) => (
+                  <div key={period} className="rounded-xl border p-4">
+                    <div className="font-medium">{period.replace('-', '–')}</div>
+                    <ul className="list-disc list-inside mt-2 space-y-1">
+                      {plan.actions.map((a) => (
+                        <li key={a}>{a}</li>
+                      ))}
+                    </ul>
+                    {plan.metrics.length > 0 && (
+                      <div className="text-xs text-slate-500 mt-2">
+                        メトリクス: {plan.metrics.join(', ')}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <h3 className="text-base font-semibold">推奨資格</h3>
+              <ul className="mt-2 space-y-2 text-sm text-slate-700">
+                {cv.careerSupport.certifications.map((c) => (
+                  <li key={c.name} className="rounded-xl border p-4">
+                    <div className="font-medium">{c.name}</div>
+                    <div className="text-xs text-slate-500 mt-1">
+                      理由: {c.reason} / 時期: {c.timing}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div>
+              <h3 className="text-base font-semibold">学習計画</h3>
+              <ul className="mt-2 list-disc list-inside text-sm text-slate-700 space-y-1">
+                {cv.careerSupport.learningPlan.map((l, idx) => (
+                  <li key={idx}>
+                    トピック: {l.topic} / モジュール: {l.module} / 実践課題: {l.task}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div>
+              <h3 className="text-base font-semibold">メンタリング活用Tips</h3>
+              <ul className="mt-2 list-disc list-inside text-sm text-slate-700 space-y-1">
+                {cv.careerSupport.mentoringTips.map((m) => (
+                  <li key={m}>{m}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
         </section>
       )}
     </div>

--- a/components/SalaryChart.tsx
+++ b/components/SalaryChart.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const SalaryChartDynamic = dynamic(() => import("./salary/SalaryChartInner"), { ssr: false });
+
+export default function SalaryChart({ data }: { data: { stage: string; value: number }[] }) {
+  return (
+    <div className="w-full h-64">
+      <SalaryChartDynamic data={data} />
+    </div>
+  );
+}

--- a/components/salary/SalaryChartInner.tsx
+++ b/components/salary/SalaryChartInner.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
+
+export default function SalaryChartInner({ data }: { data: { stage: string; value: number }[] }) {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <LineChart data={data}>
+        <XAxis dataKey="stage" />
+        <YAxis />
+        <Tooltip />
+        <Line type="monotone" dataKey="value" stroke="#8884d8" />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}


### PR DESCRIPTION
## Summary
- extend API to generate structured career support details
- show target roles, salary trend graph, skill gap, roadmap, certifications, learning plan, and mentoring tips
- add SalaryChart component using Recharts for salary progression

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689a999b826c832689aa868a1d4df0d3