### PR TITLE
fix type narrowing in ask route

### DIFF
--- a/app/api/ask/route.ts
+++ b/app/api/ask/route.ts
@@ -13,7 +13,10 @@ function computeProgress(history: QA[]) {
   return Math.round(ratio * 100);
 }
 
-function pickNextField(history: QA[]): string | null {
+// Pick the next field that has not yet been covered in the interview history.
+// Returning `FieldKey | null` allows TypeScript to correctly narrow the type
+// and index into `FALLBACK_QUESTIONS` without requiring additional casts.
+function pickNextField(history: QA[]): FieldKey | null {
   const covered = new Set(history.map(h => h.field));
   for (const f of REQUIRED_FIELDS) {
     if (!covered.has(f)) return f;


### PR DESCRIPTION
## Summary
- ensure `pickNextField` returns a typed `FieldKey` so fallback questions are indexed safely

## Testing
- `npx tsc --noEmit && echo 'tsc success'`


------
https://chatgpt.com/codex/tasks/task_e_689b14231cf483269d5496026b0a5fe0