### PR TITLE
Add timeout for question generation

### DIFF
--- a/app/api/ask/route.ts
+++ b/app/api/ask/route.ts
@@ -4,6 +4,7 @@ import { REQUIRED_FIELDS, FieldKey } from "@/lib/fields";
 
 export const runtime = "nodejs";
 export const maxDuration = 120;
+const OPENAI_TIMEOUT_MS = 8_000;
 
 type QA = { field: string; question: string; answer: string };
 
@@ -70,15 +71,18 @@ ${JSON.stringify(history || [], null, 2)}
 - management: チーム規模/期間/体制/役割
 - other: 補足事項/強み/興味関心`;
 
-    const res = await openai.chat.completions.create({
-      model: OPENAI_MODEL,
-      temperature: 0.4,
-      messages: [
-        { role: "system", content: sys },
-        { role: "user", content: user },
-      ],
-      response_format: { type: "json_object" },
-    });
+    const res = await openai.chat.completions.create(
+      {
+        model: OPENAI_MODEL,
+        temperature: 0.4,
+        messages: [
+          { role: "system", content: sys },
+          { role: "user", content: user },
+        ],
+        response_format: { type: "json_object" },
+      },
+      { timeout: OPENAI_TIMEOUT_MS }
+    );
 
     const content = res.choices[0]?.message?.content || "{}";
     parsed = JSON.parse(content);


### PR DESCRIPTION
## Summary
- limit OpenAI question generation to 8 seconds to shorten gaps between questions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(prompts for ESLint configuration; not fully executed)*

------
https://chatgpt.com/codex/tasks/task_e_689b250fd2e8832688d2e1217336a4aa